### PR TITLE
chore(migrate): to *-artifact v3+ -> v4+

### DIFF
--- a/.github/workflows/renovate-config-validator.yaml
+++ b/.github/workflows/renovate-config-validator.yaml
@@ -19,4 +19,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: suzuki-shunsuke/github-action-renovate-config-validator@b7cd2b598bb51d071a2474e98f55cc25f91abec1 # v0.1.3
+      - uses: suzuki-shunsuke/github-action-renovate-config-validator@b54483862375f51910a60c4f498e927d4f3df466 # v1.0.1

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "config:base",
+    "config:recommended",
     "helpers:pinGitHubActionDigests",
     "github>suzuki-shunsuke/renovate-config",
     "github>aquaproj/aqua-renovate-config#1.13.0"

--- a/restore/action.yaml
+++ b/restore/action.yaml
@@ -10,11 +10,12 @@ inputs:
     required: false
 outputs:
   download-path:
+    description: 'Path to the downloaded artifact'
     value: ${{steps.download.outputs.download-path}}
 runs:
   using: composite
   steps:
-    - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # tag=v3.0.2
+    - uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # tag=v4.1.1
       id: download
       with:
         name: ${{inputs.cache-name}}

--- a/store/action.yaml
+++ b/store/action.yaml
@@ -21,7 +21,7 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
-    - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+    - uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
       with:
         name: ci-info
         path: ${{env.CI_INFO_TEMP_DIR}}


### PR DESCRIPTION
# Observation:
PR https://github.com/suzuki-shunsuke/ci-info-action/pull/409 and https://github.com/suzuki-shunsuke/ci-info-action/pull/408 are failling are failing. (Probably because they are interdependent)
The action uses upload-artifact@v3, download-artifact@v3, and checkout@v3 which are deprecated because they are based on node 16.

# PR Summary:

    Migration from upload-artifact@v3 -> v4
    Migration from download-artifact@v3 -> v4
    Migration from checkout@v3 -> v4
    Migration of the renovate configuration from config:base -> config:recommends

# Breaking Change: 
As indicated here: https://github.com/actions/toolkit/tree/%40actions/artifact%402.0.1/packages/artifact Download-artifact and Upload-artifact in v4 do not work on GHES! So... ci-info-action with theses updates too.